### PR TITLE
Don't init .auth object until .onLoad

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gcalendr
 Type: Package
 Title: Read Events From Google Calendar
-Version: 0.2.1.9004
+Version: 0.2.1.9005
 Authors@R: 
     c(person("Andrie", 
         "de Vries", 

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -1,0 +1,6 @@
+.onLoad <- function(libname, pkgname) {
+  .auth <<- gargle::init_AuthState(
+    package     = "gcalendr",
+    auth_active = TRUE
+  )
+}

--- a/R/gcalendr_auth.R
+++ b/R/gcalendr_auth.R
@@ -10,10 +10,8 @@ calendar_app <- function() {
   )
 }
 
-.auth <- gargle::init_AuthState(
-  package     = "gcalendr",
-  auth_active = TRUE
-)
+# Initialized in .onLoad.
+.auth <- NULL
 
 # The roxygen comments for these functions are mostly generated from data
 # in this list and template text maintained in gargle.


### PR DESCRIPTION
Creating the .auth object directly at the top-level means the code
from gargle is snapshotted at build time.

This is needed for r-lib/gargle#157, but is a good change even without that PR.
